### PR TITLE
Add sonarqube plugin to Jenkins s2i image

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -88,3 +88,4 @@ blueocean-dashboard:1.0.1
 blueocean:1.0.1
 pipeline-github-lib:1.0
 github-organization-folder:1.6
+sonar:2.6.1


### PR DESCRIPTION
This adds the SonarQube plugin to the Jenkins s2i plugin

#### What does this PR do?
Added sonarqube plugin to plugins.txt

#### Is there a relevant Issue open for this?
JIRA #975

#### Are there any other relevant resources that should be reviewed as well?
https://wiki.jenkins-ci.org/display/JENKINS/SonarQube+plugin
https://github.com/InfoSec812/openshift-sonarqube

#### Who would you like to review this?
/cc @sherl0cks 
